### PR TITLE
Run PEP8 on content

### DIFF
--- a/src/Lab1_ExtractAffiliation.py
+++ b/src/Lab1_ExtractAffiliation.py
@@ -5,7 +5,8 @@ affiliations = mag.getDataframe('Affiliations')
 affiliations.show(10)
 
 # Extract the AffiliationId for Microsoft
-microsoft = affiliations.where(affiliations.NormalizedName == 'microsoft').select(affiliations.AffiliationId, affiliations.DisplayName)
+microsoft = affiliations.where(affiliations.NormalizedName == 'microsoft').select(
+    affiliations.AffiliationId, affiliations.DisplayName)
 
 # Optional: peek the result
 microsoft.show()

--- a/src/Lab2_UnionVenues.py
+++ b/src/Lab2_UnionVenues.py
@@ -1,9 +1,9 @@
-#Load ConferenceSeries data
+# Load ConferenceSeries data
 conferences = mag.getDataframe('ConferenceSeries')
 # Optional: peek result
 conferences.show(10)
 
-#Load Journals data
+# Load Journals data
 journals = mag.getDataframe('Journals')
 # Optional: peek result
 journals.show(10)

--- a/src/Lab3_JoinPaperAuthorAffiliation.py
+++ b/src/Lab3_JoinPaperAuthorAffiliation.py
@@ -9,14 +9,15 @@ paperAuthorAffiliations.show(10)
 # Filter PaperAuthorAffiliations by AffiliationId
 orgPaperAuthorAffiliation = paperAuthorAffiliations \
     .join(affiliations, paperAuthorAffiliations.AffiliationId == affiliations.AffiliationId, 'inner') \
-    .select(paperAuthorAffiliations.PaperId, paperAuthorAffiliations.AuthorId, \
+    .select(paperAuthorAffiliations.PaperId, paperAuthorAffiliations.AuthorId,
             affiliations.AffiliationId, paperAuthorAffiliations.AuthorSequenceNumber)
 
 # Optional: peek result
 orgPaperAuthorAffiliation.show(10)
 
 # Optional: Count number of rows in result
-print('Number of rows in PaperAuthorAffiliation: {}'.format(orgPaperAuthorAffiliation.count()))
+print('Number of rows in PaperAuthorAffiliation: {}'.format(
+    orgPaperAuthorAffiliation.count()))
 
 # Output result
 asu.save(orgPaperAuthorAffiliation, 'PaperAuthorAffiliationRelationship.csv')

--- a/src/Lab4_CreateTable_Extract.py
+++ b/src/Lab4_CreateTable_Extract.py
@@ -1,12 +1,13 @@
 from pyspark.sql.functions import concat, lit, log, when
 
-#Load PaperAuthorAffiliationRelationship data from previous output
+# Load PaperAuthorAffiliationRelationship data from previous output
 paperAuthorAffiliation = asu.load('PaperAuthorAffiliationRelationship.csv')
 paperAuthorAffiliation.show(10)
 
-orgAuthorIds = paperAuthorAffiliation.select(paperAuthorAffiliation.AuthorId).distinct()
+orgAuthorIds = paperAuthorAffiliation.select(
+    paperAuthorAffiliation.AuthorId).distinct()
 
-#Load Authors data
+# Load Authors data
 authors = mag.getDataframe('Authors')
 
 # Get all author details
@@ -20,21 +21,26 @@ orgAuthors.show(10)
 # Output result
 asu.save(orgAuthors, 'Author.csv')
 
-#Load Papers data
+# Load Papers data
 papers = mag.getDataframe('Papers')
 
-papers = papers.withColumn('Prefix', lit('https://academic.microsoft.com/#/detail/'))
+papers = papers.withColumn('Prefix', lit(
+    'https://academic.microsoft.com/#/detail/'))
 
 # Get all paper details
-orgPaperIds = paperAuthorAffiliation.select(paperAuthorAffiliation.PaperId).distinct()
+orgPaperIds = paperAuthorAffiliation.select(
+    paperAuthorAffiliation.PaperId).distinct()
 
 orgPapers = papers \
     .join(orgPaperIds, papers.PaperId == orgPaperIds.PaperId) \
     .where(papers.Year >= 1991) \
-    .select(papers.PaperId, papers.PaperTitle.alias('Title'), papers.EstimatedCitation.alias('CitationCount'), \
-            papers.Date, when(papers.DocType.isNull(), 'Not available').otherwise(papers.DocType).alias('PublicationType'), \
-            log(papers.Rank).alias('LogProb'), concat(papers.Prefix, papers.PaperId).alias('Url'), \
-            when(papers.ConferenceSeriesId.isNull(), papers.JournalId).otherwise(papers.ConferenceSeriesId).alias('VId'), \
+    .select(papers.PaperId, papers.PaperTitle.alias('Title'), papers.EstimatedCitation.alias('CitationCount'),
+            papers.Date, when(papers.DocType.isNull(), 'Not available').otherwise(
+                papers.DocType).alias('PublicationType'),
+            log(papers.Rank).alias('LogProb'), concat(
+                papers.Prefix, papers.PaperId).alias('Url'),
+            when(papers.ConferenceSeriesId.isNull(), papers.JournalId).otherwise(
+                papers.ConferenceSeriesId).alias('VId'),
             papers.Year)
 
 # Optional: peek result

--- a/src/Lab5_CreateTableByTvf.py
+++ b/src/Lab5_CreateTableByTvf.py
@@ -19,7 +19,8 @@ orgPaperFieldOfStudy.show(10)
 asu.save(orgPaperFieldOfStudy, 'PaperFieldOfStudyRelationship.csv')
 
 # Get all field-of-study Ids for the input organization
-orgFieldOfStudyIds = orgPaperFieldOfStudy.select(orgPaperFieldOfStudy.FieldOfStudyId).distinct()
+orgFieldOfStudyIds = orgPaperFieldOfStudy.select(
+    orgPaperFieldOfStudy.FieldOfStudyId).distinct()
 
 # Get all field-of-study details for the input organization
 orgFiledOfStudy = fieldOfStudy \

--- a/src/Lab6_GetPartnerData.py
+++ b/src/Lab6_GetPartnerData.py
@@ -16,13 +16,15 @@ authors = mag.getDataframe('Authors')
 # Get all Paper-Author-Affiliation relationships for papers published by the input organization
 orgAllPaperAuthorAffiliations = paperAuthorAffiliations \
     .join(orgPapers, paperAuthorAffiliations.PaperId == orgPapers.PaperId, 'inner') \
-    .select(orgPapers.PaperId, paperAuthorAffiliations.AuthorId, \
+    .select(orgPapers.PaperId, paperAuthorAffiliations.AuthorId,
             paperAuthorAffiliations.AffiliationId, paperAuthorAffiliations.AuthorSequenceNumber)
 
 # Get partner Paper-Author-Affiliation relationships by excluding those relationships of the input organization
-partnerPaperAuthorAffiliation = orgAllPaperAuthorAffiliations.subtract(orgPaperAuthorAffiliation)
+partnerPaperAuthorAffiliation = orgAllPaperAuthorAffiliations.subtract(
+    orgPaperAuthorAffiliation)
 partnerPaperAuthorAffiliation.show(10)
-asu.save(partnerPaperAuthorAffiliation, 'PartnerPaperAuthorAffiliationRelationship.csv')
+asu.save(partnerPaperAuthorAffiliation,
+         'PartnerPaperAuthorAffiliationRelationship.csv')
 
 # Get all partner affiliation Ids
 partnerAffiliationIds = partnerPaperAuthorAffiliation \
@@ -38,7 +40,8 @@ partnerAffiliations.show(10)
 asu.save(partnerAffiliations, 'PartnerAffiliation.csv')
 
 # Get all partner author Ids
-partnerAuthorIds = partnerPaperAuthorAffiliation.select(partnerPaperAuthorAffiliation.AuthorId).distinct()
+partnerAuthorIds = partnerPaperAuthorAffiliation.select(
+    partnerPaperAuthorAffiliation.AuthorId).distinct()
 partnerAuthors = authors.join(partnerAuthorIds, partnerAuthorIds.AuthorId == authors.AuthorId) \
                         .select(partnerAuthorIds.AuthorId, authors.DisplayName.alias('AuthorName'))
 partnerAuthors.show(10)


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.